### PR TITLE
Use strings.Builder instead of bytes.Buffer

### DIFF
--- a/core.go
+++ b/core.go
@@ -7,7 +7,6 @@ package strset
 */
 
 import (
-	"bytes"
 	"sort"
 	"strings"
 )
@@ -72,11 +71,11 @@ func (s Set) ToSlice() []string {
 func (s Set) String() string {
 	elems := s.ToSlice()
 	sort.Strings(elems)
-	var buf bytes.Buffer
-	buf.WriteString("Set{")
-	buf.WriteString(strings.Join(elems, " "))
-	buf.WriteByte('}')
-	return buf.String()
+	var builder strings.Builder
+	builder.WriteString("Set{")
+	builder.WriteString(strings.Join(elems, " "))
+	builder.WriteByte('}')
+	return builder.String()
 }
 
 // allIn reports whether all elements of s exist in other.


### PR DESCRIPTION
Since version 1.10, the language supports strings.Builder. This builder is more optimized than bytes.Buffer (https://medium.com/@thuc/8-notes-about-strings-builder-in-golang-65260daae6e9). In addition, the packge bytes was only used in that part of the code, reducing an import after this commit.